### PR TITLE
Fix compilation on Fedora/OpenSuse

### DIFF
--- a/iwlib.cabal
+++ b/iwlib.cabal
@@ -1,5 +1,5 @@
 name:                iwlib
-version:             0.1.0
+version:             0.1.1
 synopsis:            Bindings for the iw C library
 description:
   A binding to the iw library for getting info about the current WiFi connection.
@@ -24,5 +24,5 @@ library
   includes:            iwlib.h
   default-language:    Haskell2010
   exposed-modules:     Network.IWlib
-  extra-libraries:     iw
+  extra-libraries:     iw m
   ghc-options:         -Wall


### PR DESCRIPTION
Related to issue #1
This is done by specifying the m library for the preprocessing phase. This change made me able to compile iwlib on Fedora 31